### PR TITLE
WSME REST Capability

### DIFF
--- a/chardetails/expose.py
+++ b/chardetails/expose.py
@@ -1,0 +1,12 @@
+from chardetails.core import CharDetails
+
+def chardetails_getdetails(text):
+    C = CharDetails()
+    result = C.getdetails(text)
+    # Conflict with the signature.
+    del result['Characters']
+    return result
+
+def get_details():
+    return [chardetails_getdetails, str, {str:{str:str}}]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = chardetails
+author = Santhosh Thottingal
+author-email = santhosh.thottingal@gmail.com
+summary = Unicode character details Library
+license = LGPL-3.0
+description-file =
+  README.rst
+home-page = https://libindic.org/chardetails
+requires-python = >=2.7
+classifier =
+  Development Status :: 5 - Production/Stable
+  License :: DFSG approved
+  License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
+  Operating System :: OS Independent
+  Intended Audience :: Developers
+  Intended Audience :: Information Technology
+  Programming Language :: Python
+
+[files]
+packages =
+ chardetails
+
+[entry_points]
+libindic.api.rest =
+    getdetails = chardetails.expose:get_details
+
+[wheel]
+universal=1
+    

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,8 @@
 #!/usr/bin/env python
-
-from setuptools import setup, find_packages
-
-name = "chardetails"
+from setuptools import setup
 
 setup(
-    name = name,
-    version = "0.2.1",
-    url = "http://silpa.org.in/chardetails",
-    license = "LGPL-3.0",
-    description = "Unicode character details Library",
-    author = "Santhosh Thottingal",
-    author_email = "santhosh.thottingal@gmail.com",
-    long_description = "This library helps to get details of \
-unicode characters.",
-    packages = find_packages('.'),
-    package_data = {'.':[]},
-    include_package_data = True,
-    setup_requires = ['setuptools-git'],
-    install_requires = ['setuptools'],
-    test_suite="tests",
-    zip_safe = False,
-    )
+    setup_requires=['pbr'],
+    pbr=True
+)
+


### PR DESCRIPTION
* chardetails/expose.py ->
Functions which enable WSME REST
From the result, key 'Characters' has been discarded as a dirty
hack. This brings uniformity in the type required by signature.

* setup.cfg, setup.py ->
pbr enabled. Entrypoints added for WSME REST